### PR TITLE
Add reusable WebComponents for common UI elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,69 @@ Copilot Workspaceは、開発者が共同でコードを作成し、レビュー
    ```python
    automation.auto_merge("REPOSITORY_NAME", "PULL_REQUEST_NUMBER")
    ```
+
+## WebComponentsの使用方法
+
+### 概要
+このリポジトリには、動的なアプリケーションを作成するためのさまざまなWebComponentのテンプレートモジュールが含まれています。以下の手順に従って、WebComponentの機能を使用してください。
+
+### インストール
+1. `src/components` ディレクトリ内のファイルをダウンロードします。
+
+### 使用方法
+
+#### ButtonComponent
+1. `src/components/ButtonComponent.js` をインポートします。
+   ```html
+   <script src="src/components/ButtonComponent.js"></script>
+   ```
+
+2. `button-component` タグを使用してボタンを作成します。
+   ```html
+   <button-component>Click me</button-component>
+   ```
+
+3. ボタンクリックイベントをハンドリングします。
+   ```javascript
+   document.querySelector('button-component').addEventListener('button-click', (event) => {
+     console.log(event.detail.message);
+   });
+   ```
+
+#### FormComponent
+1. `src/components/FormComponent.js` をインポートします。
+   ```html
+   <script src="src/components/FormComponent.js"></script>
+   ```
+
+2. `form-component` タグを使用してフォームを作成します。
+   ```html
+   <form-component></form-component>
+   ```
+
+3. フォーム送信イベントをハンドリングします。
+   ```javascript
+   document.querySelector('form-component').addEventListener('form-submit', (event) => {
+     console.log(event.detail);
+   });
+   ```
+
+#### ModalComponent
+1. `src/components/ModalComponent.js` をインポートします。
+   ```html
+   <script src="src/components/ModalComponent.js"></script>
+   ```
+
+2. `modal-component` タグを使用してモーダルを作成します。
+   ```html
+   <modal-component>
+     <p>Modal content goes here.</p>
+   </modal-component>
+   ```
+
+3. モーダルを開くおよび閉じるイベントをハンドリングします。
+   ```javascript
+   const modal = document.querySelector('modal-component');
+   modal.openModal();
+   modal.closeModal();
+   ```

--- a/src/components/ButtonComponent.js
+++ b/src/components/ButtonComponent.js
@@ -1,0 +1,43 @@
+class ButtonComponent extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this.render();
+  }
+
+  render() {
+    this.shadowRoot.innerHTML = `
+      <style>
+        button {
+          background-color: #6200ea;
+          color: white;
+          border: none;
+          padding: 10px 20px;
+          text-align: center;
+          text-decoration: none;
+          display: inline-block;
+          font-size: 16px;
+          margin: 4px 2px;
+          cursor: pointer;
+          border-radius: 4px;
+        }
+      </style>
+      <button><slot></slot></button>
+    `;
+
+    this.shadowRoot.querySelector('button').addEventListener('click', () => {
+      this.handleClick();
+    });
+  }
+
+  handleClick() {
+    const event = new CustomEvent('button-click', {
+      detail: {
+        message: 'Button clicked!'
+      }
+    });
+    this.dispatchEvent(event);
+  }
+}
+
+customElements.define('button-component', ButtonComponent);

--- a/src/components/FormComponent.js
+++ b/src/components/FormComponent.js
@@ -1,0 +1,55 @@
+class FormComponent extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this.render();
+  }
+
+  render() {
+    this.shadowRoot.innerHTML = `
+      <style>
+        form {
+          display: flex;
+          flex-direction: column;
+          gap: 10px;
+        }
+        input, button {
+          padding: 10px;
+          font-size: 16px;
+        }
+        button {
+          background-color: #6200ea;
+          color: white;
+          border: none;
+          cursor: pointer;
+          border-radius: 4px;
+        }
+      </style>
+      <form>
+        <input type="text" name="name" placeholder="Name" required>
+        <input type="email" name="email" placeholder="Email" required>
+        <button type="submit">Submit</button>
+      </form>
+    `;
+
+    this.shadowRoot.querySelector('form').addEventListener('submit', (event) => {
+      this.handleSubmit(event);
+    });
+  }
+
+  handleSubmit(event) {
+    event.preventDefault();
+    const formData = new FormData(event.target);
+    const data = {};
+    formData.forEach((value, key) => {
+      data[key] = value;
+    });
+
+    const eventDetail = new CustomEvent('form-submit', {
+      detail: data
+    });
+    this.dispatchEvent(eventDetail);
+  }
+}
+
+customElements.define('form-component', FormComponent);

--- a/src/components/ModalComponent.js
+++ b/src/components/ModalComponent.js
@@ -1,0 +1,65 @@
+class ModalComponent extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this.render();
+  }
+
+  render() {
+    this.shadowRoot.innerHTML = `
+      <style>
+        .modal {
+          display: none;
+          position: fixed;
+          z-index: 1;
+          left: 0;
+          top: 0;
+          width: 100%;
+          height: 100%;
+          overflow: auto;
+          background-color: rgb(0,0,0);
+          background-color: rgba(0,0,0,0.4);
+        }
+        .modal-content {
+          background-color: #fefefe;
+          margin: 15% auto;
+          padding: 20px;
+          border: 1px solid #888;
+          width: 80%;
+        }
+        .close {
+          color: #aaa;
+          float: right;
+          font-size: 28px;
+          font-weight: bold;
+        }
+        .close:hover,
+        .close:focus {
+          color: black;
+          text-decoration: none;
+          cursor: pointer;
+        }
+      </style>
+      <div class="modal">
+        <div class="modal-content">
+          <span class="close">&times;</span>
+          <slot></slot>
+        </div>
+      </div>
+    `;
+
+    this.shadowRoot.querySelector('.close').addEventListener('click', () => {
+      this.closeModal();
+    });
+  }
+
+  openModal() {
+    this.shadowRoot.querySelector('.modal').style.display = 'block';
+  }
+
+  closeModal() {
+    this.shadowRoot.querySelector('.modal').style.display = 'none';
+  }
+}
+
+customElements.define('modal-component', ModalComponent);


### PR DESCRIPTION
Add reusable WebComponents for common UI elements and update documentation.

* **ButtonComponent**: Create `ButtonComponent.js` with a class `ButtonComponent` extending `HTMLElement`. Implement methods for rendering and handling button clicks. Add styles for the button.
* **FormComponent**: Create `FormComponent.js` with a class `FormComponent` extending `HTMLElement`. Implement methods for rendering and handling form submissions. Add styles for the form and its elements.
* **ModalComponent**: Create `ModalComponent.js` with a class `ModalComponent` extending `HTMLElement`. Implement methods for rendering and handling modal interactions. Add styles for the modal and its content.
* **Documentation**: Update `README.md` to include instructions for using `ButtonComponent`, `FormComponent`, and `ModalComponent`. Provide examples for rendering and handling interactions with these components.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AgAmemnno/copilot-web-demo/pull/6?shareId=8216986e-974d-4f95-a4a6-d92fa95f1805).